### PR TITLE
Added pipx method of Installation for Subdomainator

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -153,11 +153,8 @@ chmod +x findomain
 sudo mv findomain /usr/bin/findomain
 
 #subdomainator
-git clone https://github.com/RevoltSecurities/Subdominator.git
-cd Subdominator
-pip3 install -r requirements.txt $bsp
-python3 setup.py install
-cd ../
+pipx install git+https://github.com/RevoltSecurities/Subdominator
+
 
 #shrewdeye
 git clone https://github.com/tess-ss/shrewdeye-bash.git


### PR DESCRIPTION
`pipx` method of installation seems more favorable for all types of linux as well in Termux .

In this change, I have modified the traditional installation with pipx as mentioned in subdomainator too.

` pipx install git+https://github.com/RevoltSecurities/Subdominator`


Before:

![subdominatorError](https://github.com/user-attachments/assets/b3beab13-a112-4b33-89eb-e0649a560058)


After:
![success](https://github.com/user-attachments/assets/ffc1018f-32a9-4980-9189-ac1ba7352972)
