### PR TITLE
Added check for GOROOT and GOPATH exports in the script

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -53,8 +53,7 @@ if ! command -v go &> /dev/null; then
 fi
 
 
-#add GOPATH
-# Added Check for GOROOT too
+#check GOPATH abd GOROOT
 if [ -f ~/.bashrc ]; then
     if ! grep -q "export GOPATH=" ~/.bashrc && ! grep -q "export GOROOT=" ~/.bashrc; then
         echo "export GOROOT=/usr/local/go" >> ~/.bashrc
@@ -72,7 +71,6 @@ elif [ -f ~/.zshrc ]; then
 else
     echo "~/.bashrc or ~/.zshrc not found"
 fi
-
 
 
 

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -54,14 +54,17 @@ fi
 
 
 #add GOPATH
+# Added Check for GOROOT too
 if [ -f ~/.bashrc ]; then
-    if ! grep -q "export GOPATH=" ~/.bashrc; then
+    if ! grep -q "export GOPATH=" ~/.bashrc && ! grep -q "export GOROOT=" ~/.bashrc; then
+        echo "export GOROOT=/usr/local/go" >> ~/.bashrc
         echo "export GOPATH=\$HOME/go" >> ~/.bashrc
         echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.bashrc
     fi
     source ~/.bashrc
 elif [ -f ~/.zshrc ]; then
-    if ! grep -q "export GOPATH=" ~/.zshrc; then
+    if ! grep -q "export GOPATH=" ~/.zshrc && ! grep -q "export GOROOT=" ~/.zshrc; then
+        echo "export GOROOT=/usr/local/go" >> ~/.zshrc
         echo "export GOPATH=\$HOME/go" >> ~/.zshrc
         echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.zshrc
     fi
@@ -69,6 +72,7 @@ elif [ -f ~/.zshrc ]; then
 else
     echo "~/.bashrc or ~/.zshrc not found"
 fi
+
 
 
 


### PR DESCRIPTION
Hello there, 

First of all thank you for your amazing tool. It saves a lot of time .

In this PR, I have added script that check's not only for `GOPATH ` but also for `GOROOT`.

Before this code   ignored go path exported from **GOROOT** method . You can see below `path for go is exported again`.

![gopathdouble](https://github.com/user-attachments/assets/6db738c0-4b8d-47d1-aa04-f2797420b2f2)

`_As this won't cause problem. Double path is exported , but let's make this tool perfect from all side that we can ._
`
This changes detect's , **GOROOT**  too making terminal Clean. 
As well we can add message like `Path already exported ` or something to make it clear to audience.